### PR TITLE
feat: add backdrop to agenda

### DIFF
--- a/src/agenda.js
+++ b/src/agenda.js
@@ -22,8 +22,15 @@ const AGENDA= [
 ]
 
 export function Agenda() {
+  const backdrop = document.createElement("div");
+  backdrop.className = styles.agendaBackdrop;
+
   const container = document.createElement("div");
   container.className = styles.agendaContainer;
+
+  backdrop.addEventListener("click", () => {
+    document.dispatchEvent(new CustomEvent("equinox:closeAgenda"));
+  });
 
   AGENDA.forEach((day) => {
     const col = document.createElement("div");
@@ -51,6 +58,7 @@ export function Agenda() {
 
     container.appendChild(col);
   });
+  backdrop.appendChild(container);
 
-  return container;
+  return backdrop;
 }

--- a/src/agenda.module.css
+++ b/src/agenda.module.css
@@ -1,3 +1,14 @@
+.agendaBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(8px);
+  z-index: 100;
+}
+
 .agendaContainer {
   display: flex;
   flex-direction: row;

--- a/src/agenda.module.css
+++ b/src/agenda.module.css
@@ -7,6 +7,7 @@
   background: rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(8px);
   z-index: 100;
+  cursor: pointer;
 }
 
 .agendaContainer {

--- a/src/main.js
+++ b/src/main.js
@@ -96,3 +96,12 @@ logo.addEventListener("equinox:logoReady", () => {
     setActive(btnRegistro);
   });
 });
+
+document.addEventListener("equinox:closeAgenda", () => {
+  contentSlot.classList.add("equi-content-slot--show");
+  requestAnimationFrame(() =>
+    contentSlot.classList.remove("equi-content-slot--show")
+  );
+  showView("register");
+  setActive(btnRegistro);
+});


### PR DESCRIPTION
Added backdrop to Agenda. Now, the Agenda element can be closed when clicking on the element and the backdrop.

![Kooha-2025-09-15-16-58-48(1)](https://github.com/user-attachments/assets/7d311a31-b8d6-4424-8feb-31c389ee0e2f)

