### PR TITLE
fix: add top padding to center grid

### DIFF
--- a/src/jury.css
+++ b/src/jury.css
@@ -1,6 +1,6 @@
 .jury {
   & article {
-    padding: 12px;
+    padding: 36px 12px 12px;
     border-radius: 24px;
     box-shadow: 0 0 16px var(--main-color);
   }


### PR DESCRIPTION
### Before
<img width="1538" height="359" alt="image" src="https://github.com/user-attachments/assets/abf6e69b-3881-4193-be99-c93e757bc356" />

### After
<img width="1507" height="329" alt="image" src="https://github.com/user-attachments/assets/e1e38d43-9197-41c5-9f63-b2cc71ef0f36" />
