### PR TITLE
Adapt for 2026 edition (4-5 June)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="stylesheet" href="/src/style.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Equinox 2025</title>
+    <title>Equinox 2026</title>
   </head>
 
   <body>
@@ -184,8 +184,8 @@
       <section id="agenda" class="agenda">
         <article>
           <div class="agenda-container">
-            <div class="agenda-column" data-day="2025-09-25">
-              <h3>Jueves 25 de Septiembre</h3>
+            <div class="agenda-column" data-day="2026-06-04">
+              <h3>Jueves 4 de Junio</h3>
               <ul>
                 <li>
                   <p>Presentación del evento y reglas</p>
@@ -193,12 +193,12 @@
                   <p class="location">Escuela 42 / Online</p>
                 </li>
                 <li class="time-changed">
-                  <p>Torneo Futbolín ⚽</p>
+                  <p>TBD</p>
                   <p class="time" data-start-time="15:15">15:15</p>
                   <p class="location">Oeste 1 - Planta 7</p>
                 </li>
                 <li>
-                  <p>Trivial ❓</p>
+                  <p>TBD</p>
                   <p class="time" data-start-time="17:30">17:30</p>
                   <p class="location">UX Lab Madrid / Online</p>
                 </li>
@@ -209,8 +209,8 @@
                 </li>
               </ul>
             </div>
-            <div class="agenda-column" data-day="2025-09-26">
-              <h3>Viernes 26 de Septiembre</h3>
+            <div class="agenda-column" data-day="2026-06-05">
+              <h3>Viernes 5 de Junio</h3>
               <ul>
                 <li class="time-changed">
                   <p>Cierre de envío</p>

--- a/index.html
+++ b/index.html
@@ -325,10 +325,10 @@
       <a href="#awards" data-icon="🏆" class="tron">Premios</a>
       <a href="#jury" data-icon="👩‍⚖️" class="tron">Jurado</a>
       <a href="#faq" data-icon="❓" class="tron">FAQ</a>
-      <a href="https://forms.office.com/e/8iMg6c9uDY" target="_blank" rel="noopener noreferrer" class="tron"
+      <a href="https://forms.office.com/e/UhEibitkPr" target="_blank" rel="noopener noreferrer" class="tron"
         >Registro ↗</a
       >
-      <a href="https://forms.office.com/e/k2qZ23JZBE" target="_blank" rel="noopener noreferrer" class="tron"
+      <a href="https://forms.office.com/e/3rkj3nzedJ" target="_blank" rel="noopener noreferrer" class="tron"
         >Submit ↗</a
       >
     </aside>

--- a/src/faqs.json
+++ b/src/faqs.json
@@ -5,7 +5,7 @@
       "questions": [
         {
           "question": "¿Qué es el Equinox?",
-          "answer": "Es un Hackathon de 24 horas del CDO que se celebrará los días 25 y 26 de septiembre. Durante este tiempo, puedes participar individualmente o en equipo (de hasta 5 personas) trabajarán en un proyecto innovador, que presentarán al jurado y a sus compañeros."
+          "answer": "Es un Hackathon de 24 horas del CDO que se celebrará los días 4 y 5 de junio. Durante este tiempo, puedes participar individualmente o en equipo (de hasta 5 personas) trabajarán en un proyecto innovador, que presentarán al jurado y a sus compañeros."
         },
         {
           "question": "¿Qué tipo de ideas se pueden desarrollar?",
@@ -26,11 +26,11 @@
       "questions": [
         {
           "question": "¿Cómo me inscribo?",
-          "answer": "Te puedes inscribir desde la web oficial del evento o haciendo uso del siguiente [formulario](https://forms.office.com/e/8iMg6c9uDY)."
+          "answer": "Te puedes inscribir desde la web oficial del evento o haciendo uso del siguiente [formulario](https://forms.office.com/e/UhEibitkPr)."
         },
         {
           "question": "¿Cuál es la fecha límite de inscripción?",
-          "answer": "El formulario de registro estará disponible hasta el 22 de septiembre a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
+          "answer": "El formulario de registro estará disponible hasta el 1 de junio a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
         },
         {
           "question": "¿Qué pasa si se superan las plazas disponibles?",
@@ -60,11 +60,11 @@
         },
         {
           "question": "¿Dónde envío mi proyecto?",
-          "answer": "Puedes enviar tu proyecto desde la web oficial del evento o haciendo uso del siguiente [formulario](https://forms.office.com/e/k2qZ23JZBE)."
+          "answer": "Puedes enviar tu proyecto desde la web oficial del evento o haciendo uso del siguiente [formulario](https://forms.office.com/e/3rkj3nzedJ)."
         },
         {
           "question": "¿Cuál es la hora límite para enviar los proyectos?",
-          "answer": "El plazo de entrega cierra el 26 de septiembre a las 11h (horario Madrid)."
+          "answer": "El plazo de entrega cierra el 5 de junio a las 11h (horario Madrid)."
         },
         {
           "question": "¿Cuánto tiempo tenemos para presentar nuestro proyecto?",
@@ -81,7 +81,7 @@
         },
         {
           "question": "¿Habrá comida y bebida?",
-          "answer": "Sí, debes indicarnos en el [formulario](https://forms.office.com/e/8iMg6c9uDY) tu participación en la cena, así como si tienes alguna intolerancia alimentaria."
+          "answer": "Sí, debes indicarnos en el [formulario](https://forms.office.com/e/UhEibitkPr) tu participación en la cena, así como si tienes alguna intolerancia alimentaria."
         },
         {
           "question": "¿Habrá un canal de comunicación oficial?",


### PR DESCRIPTION
## Summary
- Agenda actualizada al **4 y 5 de junio de 2026** (jueves y viernes)
- Sustituidas las actividades "Torneo Futbolín" y "Trivial" por **TBD**
- Actualizado el título de la página a "Equinox 2026"
- Actualizados enlaces de registro y entrega a los nuevos formularios
- Actualizadas las FAQs: fechas (4-5 junio, registro hasta 1 junio, entrega 5 junio 11h) y URLs de formularios

## Test plan
- [ ] Verificar visualmente la sección de agenda (días, columnas, eventos)
- [ ] Verificar que los enlaces de Registro y Submit del aside abren el formulario correcto
- [ ] Verificar las FAQs (sección Registro, Proyectos y entregas, Logística)
- [ ] Comprobar el título en la pestaña del navegador

🤖 Generated with [Claude Code](https://claude.com/claude-code)