### PR TITLE
Update jury roles with CDO prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
             <figure>
               <img src="/images/jury/del-val.png" alt="David Del Val" />
               <figcaption class="title">David Del Val</figcaption>
-              <figcaption class="desc">Open Gateway Director</figcaption>
+              <figcaption class="desc">CDO Director Portfolio Acceleration</figcaption>
             </figure>
             <figure>
               <img src="/images/jury/julia-gonzalez.png" alt="Julia Gonzalez" />
@@ -300,12 +300,12 @@
             <figure>
               <img src="/images/jury/raul-ortega.png" alt="Raul Ortega" />
               <figcaption class="title">Raul Ortega</figcaption>
-              <figcaption class="desc">Innovation Director</figcaption>
+              <figcaption class="desc">CDO Innovation Director</figcaption>
             </figure>
             <figure>
               <img src="/images/jury/mr-x.png" alt="Mr X" />
               <figcaption class="title">Pedro Mejuto</figcaption>
-              <figcaption class="desc">Product Strategy Director</figcaption>
+              <figcaption class="desc">CDO Product Strategy Director</figcaption>
             </figure>
           </div>
         </article>


### PR DESCRIPTION
## Summary
- Actualizado el rol de **David Del Val** a "CDO Director Portfolio Acceleration"
- Añadido prefijo **CDO** a los roles del jurado que no lo tenían:
  - Raul Ortega → "CDO Innovation Director"
  - Pedro Mejuto → "CDO Product Strategy Director"
- Julia Gonzalez e Ivan Izaguirre ya tenían el prefijo

## Test plan
- [ ] Verificar visualmente la sección de jurado en la web
- [ ] Confirmar que los 5 roles aparecen con el prefijo CDO

🤖 Generated with [Claude Code](https://claude.com/claude-code)