### PR TITLE
Replace Open Gateway award with Cybersecurity

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,9 +261,9 @@
               <figcaption class="desc">Mejor proyecto asociado a IA</figcaption>
             </figure>
             <figure>
-              <img src="/images/awards/colossus.png" alt="Open Gateway Award" />
-              <figcaption class="title">Teacher's Pet Open Gateway</figcaption>
-              <figcaption class="desc">Mejor uso de las APIs de Open Gateway</figcaption>
+              <img src="/images/awards/colossus.png" alt="Cybersecurity Award" />
+              <figcaption class="title">Teacher's Pet Cybersecurity</figcaption>
+              <figcaption class="desc">Mejor proyecto asociado a Ciberseguridad</figcaption>
             </figure>
             <figure>
               <img src="/images/awards/toolbox.png" alt="Toolbox Award" />


### PR DESCRIPTION
## Summary
- Premio **Teacher's Pet Open Gateway** sustituido por **Teacher's Pet Cybersecurity**
- Descripción actualizada a "Mejor proyecto asociado a Ciberseguridad"
- Corregida la grafía a "Cybersecurity" (en inglés, consistente con los demás premios; el resto del file usa Title Case en inglés)
- Imagen `colossus.png` mantenida; alt actualizado

## Test plan
- [ ] Verificar visualmente la sección de Premios (5ª figura)

🤖 Generated with [Claude Code](https://claude.com/claude-code)