### PR TITLE
Reestructurar agenda, eliminar Jurado y referencias a Teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,17 +190,17 @@
                 <li>
                   <p>Presentación del evento y reglas</p>
                   <p class="time" data-start-time="11:00" data-end-time="11:30">11:00 - 11:30</p>
-                  <p class="location">PTE sitio</p>
+                  <p class="location">DX LAB</p>
                 </li>
                 <li>
                   <p>Actividades</p>
-                  <p class="time" data-start-time="18:00">18:00</p>
-                  <p class="location">Lab</p>
+                  <p class="time" data-start-time="12:00" data-end-time="20:00">12:00 - 20:00</p>
+                  <p class="location">DX LAB</p>
                 </li>
                 <li>
                   <p>Pizzas 🍕</p>
                   <p class="time" data-start-time="19:00">19:00</p>
-                  <p class="location">Lab</p>
+                  <p class="location">DX LAB</p>
                 </li>
               </ul>
             </div>
@@ -210,15 +210,13 @@
                 <li>
                   <p>Entrega de premios 🏅</p>
                   <p class="time" data-start-time="10:30" data-end-time="13:30">10:30 - 13:30</p>
-                  <p class="location">PTE sitio</p>
+                  <p class="location">Universitas</p>
                 </li>
               </ul>
             </div>
           </div>
           <small class="agenda-disclaimer">
             Los eventos presenciales tendrán lugar en los edificios de <strong>Distrito Telefónica</strong> en Madrid.
-            <br />
-            Habrá opción de asistir de forma remota a través de <strong>Microsoft Teams</strong>.
           </small>
         </article>
       </section>
@@ -260,33 +258,6 @@
         </article>
       </section>
 
-      <section id="jury" class="jury">
-        <article>
-          <div class="grid">
-            <figure>
-              <img src="/images/jury/mr-x.png" alt="David Martín Lambas" />
-              <figcaption class="title">David Martín Lambas</figcaption>
-              <figcaption class="desc">CDO Director Cyber Innovation Portfolio</figcaption>
-            </figure>
-            <figure>
-              <img src="/images/jury/julia-gonzalez.png" alt="Julia Gonzalez" />
-              <figcaption class="title">Julia Gonzalez</figcaption>
-              <figcaption class="desc">CDO Strategy Director</figcaption>
-            </figure>
-            <figure>
-              <img src="/images/jury/ivan-izaguirre.jpg" alt="Ivan Izaguirre" />
-              <figcaption class="title">Ivan Izaguirre</figcaption>
-              <figcaption class="desc">CDO Eng. Director</figcaption>
-            </figure>
-            <figure>
-              <img src="/images/jury/raul-ortega.png" alt="Raul Ortega" />
-              <figcaption class="title">Raul Ortega</figcaption>
-              <figcaption class="desc">CDO Innovation Director</figcaption>
-            </figure>
-          </div>
-        </article>
-      </section>
-
       <section id="faq" class="faq faq-fixed-height">
         <article>
           <div class="faq-container">
@@ -299,7 +270,6 @@
     <aside>
       <a href="#agenda" data-icon="📅" class="tron">Agenda</a>
       <a href="#awards" data-icon="🏆" class="tron">Premios</a>
-      <a href="#jury" data-icon="👩‍⚖️" class="tron">Jurado</a>
       <a href="#faq" data-icon="❓" class="tron">FAQ</a>
       <a href="https://forms.office.com/e/UhEibitkPr" target="_blank" rel="noopener noreferrer" class="tron"
         >Registro ↗</a

--- a/index.html
+++ b/index.html
@@ -184,8 +184,8 @@
       <section id="agenda" class="agenda">
         <article>
           <div class="agenda-container">
-            <div class="agenda-column" data-day="2026-06-04">
-              <h3>Jueves 4 de Junio</h3>
+            <div class="agenda-column" data-day="2026-06-25">
+              <h3>Jueves 25 de Junio</h3>
               <ul>
                 <li>
                   <p>Presentación del evento y reglas</p>
@@ -204,8 +204,8 @@
                 </li>
               </ul>
             </div>
-            <div class="agenda-column" data-day="2026-06-05">
-              <h3>Viernes 5 de Junio</h3>
+            <div class="agenda-column" data-day="2026-06-26">
+              <h3>Viernes 26 de Junio</h3>
               <ul>
                 <li>
                   <p>Entrega de premios 🏅</p>

--- a/index.html
+++ b/index.html
@@ -189,47 +189,28 @@
               <ul>
                 <li>
                   <p>Presentación del evento y reglas</p>
-                  <p class="time" data-start-time="12:00" data-end-time="12:30">12:00 - 12:30</p>
-                  <p class="location">Escuela 42 / Online</p>
-                </li>
-                <li class="time-changed">
-                  <p>Torneo Futbolín ⚽</p>
-                  <p class="time" data-start-time="15:15">15:15</p>
-                  <p class="location">Oeste 1 - Planta 7</p>
+                  <p class="time" data-start-time="11:00" data-end-time="11:30">11:00 - 11:30</p>
+                  <p class="location">PTE sitio</p>
                 </li>
                 <li>
-                  <p>Escape the bomb! 💣</p>
-                  <p class="time" data-start-time="17:30">17:30</p>
-                  <p class="location">UX Lab Madrid / Online</p>
+                  <p>Actividades</p>
+                  <p class="time" data-start-time="18:00">18:00</p>
+                  <p class="location">Lab</p>
                 </li>
                 <li>
-                  <p>Cena 🍽</p>
+                  <p>Pizzas 🍕</p>
                   <p class="time" data-start-time="19:00">19:00</p>
-                  <p class="location">UX Lab Madrid</p>
+                  <p class="location">Lab</p>
                 </li>
               </ul>
             </div>
             <div class="agenda-column" data-day="2026-06-05">
               <h3>Viernes 5 de Junio</h3>
               <ul>
-                <li class="time-changed">
-                  <p>Cierre de envío</p>
-                  <p class="time" data-start-time="10:30">10:30</p>
-                  <p class="location">Online</p>
-                </li>
-                <li class="time-changed">
-                  <p>Presentaciones de proyectos (5 minutos por proyecto)</p>
-                  <p class="time" data-start-time="11:00">11:00</p>
-                  <p class="location">Escuela 42 / Online</p>
-                </li>
-                <li>
-                  <p>Deliberación del Jurado</p>
-                  <p class="time" data-start-time="13:45">13:45</p>
-                </li>
                 <li>
                   <p>Entrega de premios 🏅</p>
-                  <p class="time" data-start-time="14:00">14:00</p>
-                  <p class="location">Escuela 42 / Online</p>
+                  <p class="time" data-start-time="10:30" data-end-time="13:30">10:30 - 13:30</p>
+                  <p class="location">PTE sitio</p>
                 </li>
               </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
         <article>
           <div class="agenda-container">
             <div class="agenda-column" data-day="2026-06-25">
-              <h3>Jueves 25 de Junio</h3>
+              <h3>Jueves 25 de junio</h3>
               <ul>
                 <li>
                   <p>Presentación del evento y reglas</p>
@@ -205,7 +205,7 @@
               </ul>
             </div>
             <div class="agenda-column" data-day="2026-06-26">
-              <h3>Viernes 26 de Junio</h3>
+              <h3>Viernes 26 de junio</h3>
               <ul>
                 <li>
                   <p>Entrega de premios 🏅</p>

--- a/src/faqs.json
+++ b/src/faqs.json
@@ -5,7 +5,7 @@
       "questions": [
         {
           "question": "¿Qué es el Equinox?",
-          "answer": "Es un Hackathon de 24 horas del CDO que se celebrará los días 4 y 5 de junio. Durante este tiempo, puedes participar individualmente o en equipo (de hasta 5 personas) trabajarán en un proyecto innovador, que presentarán al jurado y a sus compañeros."
+          "answer": "Es un Hackathon de 24 horas del CDO que se celebrará los días 25 y 26 de junio. Durante este tiempo, puedes participar individualmente o en equipo (de hasta 5 personas) trabajarán en un proyecto innovador, que presentarán al jurado y a sus compañeros."
         },
         {
           "question": "¿Qué tipo de ideas se pueden desarrollar?",
@@ -30,7 +30,7 @@
         },
         {
           "question": "¿Cuál es la fecha límite de inscripción?",
-          "answer": "El formulario de registro estará disponible hasta el 1 de junio a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
+          "answer": "El formulario de registro estará disponible hasta el 22 de junio a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
         },
         {
           "question": "¿Qué pasa si se superan las plazas disponibles?",
@@ -64,7 +64,7 @@
         },
         {
           "question": "¿Cuál es la hora límite para enviar los proyectos?",
-          "answer": "El plazo de entrega cierra el 5 de junio a las 10:30h (horario Madrid)."
+          "answer": "El plazo de entrega cierra el 26 de junio a las 10:30h (horario Madrid)."
         },
         {
           "question": "¿Cuánto tiempo tenemos para presentar nuestro proyecto?",

--- a/src/faqs.json
+++ b/src/faqs.json
@@ -47,7 +47,7 @@
         },
         {
           "question": "¿Puedo participar si no tengo equipo?",
-          "answer": "¡Por supuesto! Puedes participar de forma individual o si no tienes equipo puedes comentar en el [canal de Teams](https://teams.microsoft.com/l/channel/19%3A70808c87c5074682ab31d16d42cd78b0%40thread.tacv2/Encuentra%20tu%20Equipo?groupId=5150080f-d278-407c-9654-42f1238e9d4a&tenantId=9744600e-3e04-492e-baa1-25ec245c6f10) para encontrar compañeros en la misma situación y crear un equipo con ellos."
+          "answer": "¡Por supuesto! Puedes participar de forma individual o, si no tienes equipo, te ayudaremos a encontrar compañeros en la misma situación para crear un equipo con ellos."
         }
       ]
     },
@@ -82,10 +82,6 @@
         {
           "question": "¿Habrá comida y bebida?",
           "answer": "Sí, debes indicarnos en el [formulario](https://forms.office.com/e/UhEibitkPr) tu participación en la cena, así como si tienes alguna intolerancia alimentaria."
-        },
-        {
-          "question": "¿Habrá un canal de comunicación oficial?",
-          "answer": "Sí, puedes unirte al [equipo oficial de Teams](https://teams.microsoft.com/l/channel/19%3Ax0tmUp7pLCrOpioJW9JLZ5bRxqzMP01GXyfCcCzh1P41%40thread.tacv2/General?groupId=5150080f-d278-407c-9654-42f1238e9d4a&tenantId=9744600e-3e04-492e-baa1-25ec245c6f10) del evento."
         }
       ]
     }

--- a/src/faqs.json
+++ b/src/faqs.json
@@ -30,7 +30,7 @@
         },
         {
           "question": "¿Cuál es la fecha límite de inscripción?",
-          "answer": "El formulario de registro estará disponible hasta el 22 de junio a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
+          "answer": "El formulario de registro estará disponible hasta el 23 de junio a las 23:00h. Es importante rellenarlo para participar en las actividades presenciales, ya que a partir de este formulario gestionaremos los accesos y logística para actividades presenciales. No obstante siempre será posible que presentes tu proyecto de forma online."
         },
         {
           "question": "¿Qué pasa si se superan las plazas disponibles?",


### PR DESCRIPTION
## Cambios

- **Jurado:** eliminada la sección de Jurado y su enlace de navegación.
- **Agenda:**
  - Presentación → DX LAB
  - Actividades → 12:00 - 20:00, en DX LAB
  - Pizzas 🍕 → DX LAB
  - Entrega de premios 🏅 → Universitas
- **Microsoft Teams:** eliminadas todas las referencias (disclaimer de la agenda y FAQs, incluida la pregunta "¿Habrá un canal de comunicación oficial?").

🤖 Generated with [Claude Code](https://claude.com/claude-code)